### PR TITLE
replaced VCAAmount  mapping with the more recent reactor implementation

### DIFF
--- a/plugins/lpg.cpp
+++ b/plugins/lpg.cpp
@@ -87,7 +87,8 @@ inline void LpgFilter::setVactrolResistance(float rf) {
 
 inline void LpgFilter::setVCAAmount(double amount) {
   // Not sure why this is necessary to be honest:
-  amount = (1.0 - amount) * 5e6 + 10e3;
+  // amount = (1.0 - amount) * 5e6 + 10e3;
+  amount = (1.0 - amount) * 1e6 + 5e4; // taken from reaktor implementation
   m_vcaness = amount;
 }
 


### PR DESCRIPTION
Thanks for this implementation of the Parker et al LPG, it works quite nicely and the code is oh so readable!

dunno if this is of interest to you but in case it is, here's a little update/change of the VCA amount:

I changed the amount mapping to follow the reaktor 6 Blocks implementation  of this LPG, also I found (by looking at the reaktor code) that a non-linear mapping of the VCAamount (I currently do this in the sclang `SynthDef` itself) results in quite reasonable linear behaviour when it is attached to a linearly mapped fader:

```
vca = (1+vca).log2.sqrt
```


Another thing I was considering adding (but haven't looked into it so far) is to account for non-exact values of resistors etc, by providing a random seed at UGen creation and vary resistor values randomly at instantiation time... this might be interesting when working with several LPGs in parallel/sequence.


again, great work! 