### PR TITLE
CMake: require version 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 ####################################################################################################
 # basic project config
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 set(project_name "MKPlugins")
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_modules ${CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
CMAKE_CXX_STANDARD=17 is unsupported before v3.8