### PR TITLE
Add CMAKE_OSX_DEPLOYMENT_TARGET in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@
 cmake_minimum_required(VERSION 3.8)
 set(project_name "PortedPlugins")
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_modules ${CMAKE_MODULE_PATH})
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version")
 
 set(CMAKE_CXX_STANDARD 20)
 


### PR DESCRIPTION
This should fix https://github.com/madskjeldgaard/portedplugins/issues/36

I'm using 10.10 as minimum version for now, as SuperCollider also provides build down to that version at the moment